### PR TITLE
Test parallelly-develop on GitHub Actions running macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,7 @@ jobs:
           - {os: windows-latest, r: 'release'  }
           - {os: windows-latest, r: 'oldrel'   }
 #          - {os: macOS-latest,   r: 'devel'    }
-          - {os: macOS-latest,   r: 'release', parallelly_version: ed860db, label: 'w/ compatible parallelly' }
-          - {os: macOS-latest,   r: 'release', parallelly_version: ea182e9, label: 'w/ compatible parallelly' }
+          - {os: macOS-latest,   r: 'release', parallelly_version: develop, label: 'w/ parallelly-develop' }
           - {os: macOS-latest,   r: 'release'  }
           - {os: macOS-latest,   r: 'oldrel'   }
 #          - {os: ubuntu-latest,  r: 'devel'    }

--- a/.github/workflows/doFuture.tests.extra.yaml
+++ b/.github/workflows/doFuture.tests.extra.yaml
@@ -6,7 +6,7 @@ jobs:
   R-CMD-check:
     if: "! contains(github.event.head_commit.message, '[ci skip]')"    
 
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Closes #87

The macOS-specific problem was fixed in [{parallelly 1.45.1}](https://github.com/futureverse/parallelly/blob/9e38aae1540fcea156c945bb95e0951c8833e5a2/NEWS.md#version-1451-2025-07-24), which was accepted on CRAN on 2025-07-24

This PR removes the troubleshooting jobs and adds a macOS job that tests against the branch "develop" of {parallelly} for early detection of similar problems going forward

xref: https://github.com/Merck/simtrial/issues/337, https://github.com/futureverse/parallelly/commit/b26aef3ac4ea9c4d56e544eb3795fca940c21024